### PR TITLE
Fix colon error

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -17,8 +17,7 @@ archives:
   - format: tar.gz
     # this name template makes the OS and Arch compatible with the results of uname.
     name_template: >-
-      {{ .ProjectName }}_
-      {{ .Version }}_
+      {{ .ProjectName }}_v{{ .Version }}_
       {{- title .Os }}_
       {{- if eq .Arch "amd64" }}x86_64
       {{- else if eq .Arch "386" }}i386

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -27,7 +27,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "0.3.1"
+var version = "0.4"
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{

--- a/pkg/cleaner.go
+++ b/pkg/cleaner.go
@@ -8,7 +8,7 @@ import (
 )
 
 func cleanup(links []Link, content []byte) []byte {
-	refLinkRegex := regexp.MustCompile(`\[(.*?)\]:\s(.+)(\n|$)`)
+	refLinkRegex := regexp.MustCompile(`[^\]]\[((\w+)|(\^\w+))\]:\s(.+)`)
 	content = refLinkRegex.ReplaceAll(content, []byte(""))
 	for _, link := range links {
 		if link.IsFootnote() || link.IsReference() {

--- a/pkg/cleaner_test.go
+++ b/pkg/cleaner_test.go
@@ -82,9 +82,54 @@ This is some more text.`)
 
 		output := cleanup(links, content)
 
-		if !bytes.Equal(output, expectedOutput) {
-			t.Errorf("Expected output:\n%s\n\nBut got:\n%s", expectedOutput, output)
-		}
+		compareResults(output, expectedOutput, t)
+	})
+
+	t.Run("doesn't modify content within lists", func(t *testing.T) {
+		content := []byte(`- [Craft][1]: Test`)
+		expectedOutput := []byte(`- [Craft][1]: Test`)
+
+		links := []Link{}
+		output := cleanup(links, content)
+
+		compareResults(output, expectedOutput, t)
+	})
+
+	t.Run("leaves invalid links intact", func(t *testing.T) {
+		content := []byte(`[Test]`)
+		expectedOutput := []byte(`[Test]`)
+
+		links := []Link{}
+		output := cleanup(links, content)
+
+		compareResults(output, expectedOutput, t)
+	})
+
+	t.Run("works with inline links", func(t *testing.T) {
+		content := []byte(`[Google](https://www.google.com) fdafd
+[GitHub][1]: nope
+[Wikipedia][ref] fdsf ds
+[Third link](https://www.example3.com)
+[Fourth link](https://www.example4.com)
+[Invalid Link]
+[Example page][Example]
+
+[1]: https://github.com
+[ref]: https://www.wikipedia.org
+[Example]: https://example.com`)
+
+		expectedOutput := []byte(`[Google](https://www.google.com) fdafd
+[GitHub][1]: nope
+[Wikipedia][ref] fdsf ds
+[Third link](https://www.example3.com)
+[Fourth link](https://www.example4.com)
+[Invalid Link]
+[Example page][Example]`)
+
+		links := []Link{}
+		output := cleanup(links, content)
+		compareResults(output, expectedOutput, t)
+
 	})
 }
 

--- a/pkg/cleaner_test.go
+++ b/pkg/cleaner_test.go
@@ -13,15 +13,13 @@ func TestCleanup(t *testing.T) {
 			{ID: "3", URL: "https://www.example3.com"},
 		}
 		content := []byte(`This is some text with a reference [link][1].
-[1]: https://www.example1.com`)
+    [1]: https://www.example1.com`)
 
 		expectedOutput := []byte(`This is some text with a reference [link][1].`)
 
 		output := cleanup(links, content)
 
-		if !bytes.Equal(output, expectedOutput) {
-			t.Errorf("Expected output:\n%s\n\nBut got:\n%s", expectedOutput, output)
-		}
+		compareResults(output, expectedOutput, t)
 	})
 
 	t.Run("replaces inline links with reference links", func(t *testing.T) {
@@ -34,9 +32,8 @@ func TestCleanup(t *testing.T) {
 
 		output := cleanup(links, content)
 
-		if !bytes.Equal(output, expectedOutput) {
-			t.Errorf("Expected output:\n%s\n\nBut got:\n%s", expectedOutput, output)
-		}
+		compareResults(output, expectedOutput, t)
+
 	})
 
 	t.Run("removes duplicated empty lines", func(t *testing.T) {
@@ -52,9 +49,8 @@ This is some more text.`)
 
 		output := cleanup(links, content)
 
-		if !bytes.Equal(output, expectedOutput) {
-			t.Errorf("Expected output:\n%s\n\nBut got:\n%s", expectedOutput, output)
-		}
+		compareResults(output, expectedOutput, t)
+
 	})
 
 	t.Run("removes trailing whitespace", func(t *testing.T) {
@@ -69,9 +65,8 @@ This is some more text.`)
 
 		output := cleanup(links, content)
 
-		if !bytes.Equal(output, expectedOutput) {
-			t.Errorf("Expected output:\n%s\n\nBut got:\n%s", expectedOutput, output)
-		}
+		compareResults(output, expectedOutput, t)
+
 	})
 
 	t.Run("removes footnote links", func(t *testing.T) {
@@ -92,6 +87,7 @@ This is some more text.`)
 		}
 	})
 }
+
 func TestRemoveLineContainingString(t *testing.T) {
 	content := []byte(`
 		This is a test file.
@@ -108,8 +104,13 @@ func TestRemoveLineContainingString(t *testing.T) {
 	`)
 
 	newContent := removeLineContainingString(content, "test")
+	compareResults(newContent, expectedOutput, t)
 
-	if !bytes.Equal(newContent, expectedOutput) {
-		t.Errorf("Expected output:\n%s\n\nBut got:\n%s", expectedOutput, newContent)
+}
+
+func compareResults(output []byte, expectedOutput []byte, t *testing.T) {
+	t.Helper()
+	if !bytes.Equal(output, expectedOutput) {
+		t.Errorf("Expected output:\n%s\n\nBut got:\n%s", expectedOutput, output)
 	}
 }

--- a/pkg/converter.go
+++ b/pkg/converter.go
@@ -98,11 +98,11 @@ func (c *MarkdownConverter) addLink(name string, url string, ID string) {
 }
 
 func (c *MarkdownConverter) extractLinksFromReferences() {
-	refLinkRegex := regexp.MustCompile(`\[(.*?)\]:\s(.+)`)
+	refLinkRegex := regexp.MustCompile(`(\n|^)\s*\[(.*?)\]:\s(.+)`)
 	matches := refLinkRegex.FindAllSubmatch(c.originalContent, -1)
 
 	for _, match := range matches {
-		c.addLink(string(""), string(match[2]), string(match[1]))
+		c.addLink(string(""), string(match[3]), string(match[2]))
 	}
 }
 

--- a/pkg/converter_test.go
+++ b/pkg/converter_test.go
@@ -87,8 +87,9 @@ func TestRunOnContent(t *testing.T) {
 [Wikipedia][ref] fdsf ds
 [Third link](https://www.example3.com)
 [Fourth link](https://www.example4.com)
-[Example page][Example]
 [Invalid Link]
+[Example page][Example]
+
 [1]: https://github.com
 [ref]: https://www.wikipedia.org
 [Example]: https://example.com`)
@@ -98,8 +99,8 @@ func TestRunOnContent(t *testing.T) {
 [Wikipedia][ref] fdsf ds
 [Third link][3]
 [Fourth link][4]
-[Example page][Example]
 [Invalid Link]
+[Example page][Example]
 
 [1]: https://github.com
 [2]: https://www.google.com
@@ -163,6 +164,18 @@ second line
 
 		expectedOutput := []byte(`first line
 second line
+`)
+		compareConvertResults(t, content, expectedOutput)
+	})
+
+	t.Run("doesn't modify content within lists", func(t *testing.T) {
+		content := []byte(`- [Craft][1]: Test
+
+		[1]: www.craft.eu
+`)
+		expectedOutput := []byte(`- [Craft][1]: Test
+
+[1]: www.craft.eu
 `)
 		compareConvertResults(t, content, expectedOutput)
 	})


### PR DESCRIPTION
There was en error which identified a link like `[link][reference]: ` as a link due to matching via a colon (`:`). It's now fixed.